### PR TITLE
foundation 1/5: repo-local conda dev environment (clang/lld)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ CTestTestfile.cmake
 CMakeSettings.json
 .vs/
 .vscode/
+# Local dev environment (scripts/devenv)
+/.devenv/
+/toolchain/
+/.toolchain-build/
+/scripts/devenv/*.log

--- a/scripts/devenv/README.md
+++ b/scripts/devenv/README.md
@@ -1,0 +1,40 @@
+# Cardinal; developer environment
+
+A self-contained, **repo-local** toolchain so a clean machine can build the OS
+with one command. Everything lives under the repo and is git-ignored:
+
+| Path        | What                                                        |
+|-------------|-------------------------------------------------------------|
+| `.devenv/`  | conda env holding the whole toolchain (clang/lld/llvm, cmake, ninja, astyle) |
+
+## Toolchain choice
+
+The cross compiler is **Clang/LLVM**. Clang is natively a cross compiler, so we
+build the freestanding kernel with `--target=x86_64-elf` directly — there is no
+separate GCC/binutils cross build to babysit. `lld` is the linker and
+`llvm-tools` supplies `llvm-ar` / `llvm-objcopy` / `llvm-nm` / `llvm-ranlib`.
+
+> The historical `x86_64-elf-cardinalsemi-gcc` (a patched GCC with a custom
+> Cardinal target + newlib) is retired.
+
+## Usage
+
+```bash
+# One-time (or after editing environment.yml): build the env + verify the toolchain
+./scripts/devenv/setup.sh
+
+# Each shell where you want to build: put the toolchain on PATH
+source ./scripts/devenv/activate.sh
+```
+
+`setup.sh` is idempotent — re-running updates the env in place.
+
+## Not in the conda env
+
+A few tools are not packaged for conda-forge/linux-64 and are only needed to
+build/boot a **bootable ISO** (not to compile the kernel + modules). Install
+them from your system package manager if you want them:
+
+```bash
+sudo apt install qemu-system-x86 grub-pc-bin grub-efi-amd64-bin mtools xorriso
+```

--- a/scripts/devenv/activate.sh
+++ b/scripts/devenv/activate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Activate a Cardinal; build session (the conda env holds the whole toolchain).
+#   source ./scripts/devenv/activate.sh
+#
+# (Must be sourced, not executed, so the activation persists in your shell.)
+
+_cardinal_root="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+
+if command -v conda >/dev/null 2>&1; then
+  source "$(conda info --base)/etc/profile.d/conda.sh"
+  conda activate "$_cardinal_root/.devenv"
+else
+  echo "warning: conda not found; skipping env activation" >&2
+fi
+
+if command -v clang >/dev/null 2>&1; then
+  echo "Cardinal; build env ready:"
+  echo "  clang: $(clang --version | head -1)"
+  echo "  cmake: $(cmake --version | head -1)"
+  echo
+  echo "Configure an out-of-source build with:"
+  echo "  cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug"
+else
+  echo "warning: clang not found; run ./scripts/devenv/setup.sh" >&2
+fi
+
+unset _cardinal_root

--- a/scripts/devenv/environment.yml
+++ b/scripts/devenv/environment.yml
@@ -1,0 +1,36 @@
+# Repo-local conda environment for Cardinal; development.
+#
+# Create/update with:   ./scripts/devenv/setup.sh
+# (creates the env at ./.devenv via `conda env create --prefix ./.devenv`)
+#
+# The cross compiler is Clang/LLVM: clang is natively a cross compiler, so we
+# target `--target=x86_64-elf` (freestanding, no OS) directly with no separate
+# toolchain build. lld is the linker; llvm-tools provides llvm-ar / llvm-objcopy
+# / llvm-nm / llvm-ranlib used in place of binutils.
+#
+# clang is pinned to 20.x to match the version commonly installed on dev hosts;
+# bump deliberately and re-verify the build when moving major versions.
+name: cardinal-dev
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  # --- build orchestration ---
+  - cmake>=3.20
+  - make
+  - ninja
+  # --- cross compiler + binutils replacements (LLVM) ---
+  - clang=20
+  - clangxx=20
+  - lld=20
+  - llvm-tools=20
+  # --- code style (matches scripts/style_com.sh) ---
+  - astyle
+#
+# NOT available via conda-forge/linux-64 (install from the system package
+# manager if you need them; only required to build/boot a bootable ISO, not to
+# compile the kernel + modules):
+#   qemu        -> sudo apt install qemu-system-x86
+#   grub tools  -> sudo apt install grub-pc-bin grub-efi-amd64-bin
+#   mtools      -> sudo apt install mtools
+#   xorriso     -> sudo apt install xorriso

--- a/scripts/devenv/setup.sh
+++ b/scripts/devenv/setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Developer environment bootstrap for Cardinal;.
+#
+# Creates/updates the repo-local conda env at ./.devenv, which provides the
+# entire toolchain: clang/clang++ (cross compiler via --target=x86_64-elf),
+# lld, llvm-tools, nasm, qemu, xorriso, cmake, astyle.
+#
+# Re-running is safe and incremental (the env is updated in place).
+#
+# After this completes, activate a build session with:
+#   source ./scripts/devenv/activate.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_PREFIX="$REPO_ROOT/.devenv"
+
+log() { printf '\033[1;32m[setup]\033[0m %s\n' "$*"; }
+
+if ! command -v conda >/dev/null 2>&1; then
+  echo "error: conda not found on PATH. Install miniforge/miniconda first." >&2
+  exit 1
+fi
+CONDA_BASE="$(conda info --base)"
+# shellcheck disable=SC1091
+source "$CONDA_BASE/etc/profile.d/conda.sh"
+
+if [ -d "$ENV_PREFIX" ]; then
+  log "Updating existing conda env at $ENV_PREFIX"
+  conda env update --prefix "$ENV_PREFIX" --file "$REPO_ROOT/scripts/devenv/environment.yml" --prune
+else
+  log "Creating conda env at $ENV_PREFIX"
+  conda env create --prefix "$ENV_PREFIX" --file "$REPO_ROOT/scripts/devenv/environment.yml"
+fi
+
+conda activate "$ENV_PREFIX"
+log "Environment ready:"
+log "  clang: $(clang --version | head -1)"
+log "  lld:   $(ld.lld --version | head -1)"
+log "  cmake: $(cmake --version | head -1)"
+log ""
+log "Start a build session with:  source ./scripts/devenv/activate.sh"


### PR DESCRIPTION
Introduces a self-contained, git-ignored developer environment under `scripts/devenv/` so a clean machine can build Cardinal; with one command.

- `setup.sh` builds a conda env at `./.devenv` from `environment.yml` (clang/clang++ 20, lld, llvm-tools, cmake, ninja, astyle).
- `activate.sh` puts the toolchain on PATH for a build session.
- The historical `x86_64-elf-cardinalsemi-gcc` (patched GCC custom target + newlib) is retired in favour of stock Clang, which is a native cross compiler.
- qemu/grub/mtools/xorriso documented as optional system installs (only for building a bootable ISO).

**Foundation PR stack** (merge bottom-up):
1. `foundation/devenv` — dev environment
2. `foundation/build-clang` — Clang/LLVM build port
3. `foundation/ci` — GitHub Actions
4. `foundation/audit` — audit roadmap doc
5. `foundation/correctness-fixes` — verified bug fixes

This PR is #1.