### PR TITLE
foundation 5/5: fix three verified correctness bugs

### DIFF
--- a/modules/SysReg/src/main.c
+++ b/modules/SysReg/src/main.c
@@ -372,7 +372,7 @@ int registry_readkey_ptr(const char *path, const char *keyname,
         return registry_err_typematchfailure;
     }
 
-    if (val != NULL && kvs_get_uint(key_kvs, val) != kvs_ok)
+    if (val != NULL && kvs_get_ptr(key_kvs, val) != kvs_ok)
     {
         local_spinlock_unlock(&kern_lock);
         return registry_err_failure;

--- a/servers/CoreDisplay/src/edid.c
+++ b/servers/CoreDisplay/src/edid.c
@@ -100,7 +100,7 @@ bool coredisplay_parse_edid(uint8_t *raw, edid_t *result)
             // display descriptor
             if (raw[54 + i + 3] == 0xFC)
                 for (int n_i = 0; n_i < 13; n_i++)
-                    result->display_name[n_i] = raw[54 + i + 5];
+                    result->display_name[n_i] = raw[54 + i + 5 + n_i];
         }
         else
         {

--- a/servers/CorePower/src/main.c
+++ b/servers/CorePower/src/main.c
@@ -33,7 +33,7 @@ int pwr_sendevent_g(device_pwr_class_t pwr_class, global_pwr_state_t state, int 
     pwr_device_t *device = NULL;
     int entcnt = queue_entcnt(&devices);
     for(int i = 0; i < entcnt; i++)
-        if(queue_trydequeue(&devices, (uint64_t*)device)) {
+        if(queue_trydequeue(&devices, (uint64_t*)&device)) {
             if(device->event_g != NULL && (device->dev_class & pwr_class))
                 device->event_g(state, p_state);
             queue_tryenqueue(&devices, (uint64_t)device);
@@ -49,7 +49,7 @@ int pwr_sendevent_d(device_pwr_class_t pwr_class, device_pwr_state_t state) {
     pwr_device_t *device = NULL;
     int entcnt = queue_entcnt(&devices);
     for(int i = 0; i < entcnt; i++)
-        if(queue_trydequeue(&devices, (uint64_t*)device)) {
+        if(queue_trydequeue(&devices, (uint64_t*)&device)) {
             if(device->event_d != NULL && (device->dev_class & pwr_class))
                 device->event_d(state);
             queue_tryenqueue(&devices, (uint64_t)device);


### PR DESCRIPTION
Fixes the three VERIFIED bugs from notes/AUDIT.md. Stacked on #6 (audit).

- **CoreDisplay EDID**: monitor-name descriptor parse read `raw[54+i+5]` for every character, filling `display_name` with 13 copies of one byte. Index by `n_i`.
- **CorePower**: `pwr_sendevent_g/_d` passed `(uint64_t*)device` — the NULL value of the local — to `queue_trydequeue`, which writes `*val`, dereferencing NULL. Pass `&device`.
- **SysReg**: `registry_readkey_ptr` read a `kvs_val_ptr` entry with `kvs_get_uint`, whose internal type check then always failed, so it never returned a pointer value. Use `kvs_get_ptr`.

Builds clean with clang/lld.

Part of the foundation stack (this is #5; base is the audit PR).