### PR TITLE
Fix bugs from notes/AUDIT.md (GMBUS hang, bitwise-OR, pagealloc OOM sentinel)

### DIFF
--- a/drivers/ahci/src/main.c
+++ b/drivers/ahci/src/main.c
@@ -134,6 +134,13 @@ int module_init(void *ecam_addr)
     //32 * (CMD_BUF_SIZE + FIS_SIZE + sizeof(ahci_cmdtable_t))
     size_t dma_sz = port_cnt * (CMD_BUF_SIZE + FIS_SIZE + sizeof(ahci_cmdtable_t));
     instance->port_dma.phys_addr = (uint64_t)pagealloc_alloc(0, 0, physmem_alloc_flags_zero | physmem_alloc_flags_data, dma_sz);
+    if (instance->port_dma.phys_addr == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[AHCI] Out of memory allocating port DMA region.\r\n");
+        local_spinlock_unlock(&device_init_lock);
+        sti(cli_state);
+        return -1;
+    }
     instance->port_dma.virt_addr = (uint64_t)vmem_phystovirt(instance->port_dma.phys_addr, dma_sz, vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
 
     //initialize ports

--- a/drivers/ehci/src/main.c
+++ b/drivers/ehci/src/main.c
@@ -71,7 +71,13 @@ int module_init(void *ecam_addr)
     //Frame list: 4x1024 entries
     //Each frame contains transfer descriptors
     //Queue Heads are for bulk transfers
-    instance->framelist_pmem = (uint32_t)pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data | physmem_alloc_flags_zero, KiB(4));
+    uintptr_t framelist_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data | physmem_alloc_flags_zero, KiB(4));
+    if (framelist_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[EHCI] Out of memory allocating frame list.\r\n");
+        return -1;
+    }
+    instance->framelist_pmem = (uint32_t)framelist_phys;
     instance->framelist = (uint32_t *)vmem_phystovirt((intptr_t)instance->framelist_pmem, KiB(4), vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
     instance->init_complete = false;
 

--- a/drivers/hdaudio/src/main.c
+++ b/drivers/hdaudio/src/main.c
@@ -536,6 +536,11 @@ int module_init(void *ecam_addr)
     memset(instance->cmds, 0, sizeof(hdaudio_cmd_entry_t) * instance->corb.entcnt);
 
     uintptr_t corb_rirb_buffer_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_data | physmem_alloc_flags_zero, (instance->corb.entcnt + 2 * instance->rirb.entcnt) * sizeof(uint32_t));
+    if (corb_rirb_buffer_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[HDAudio] Out of memory allocating CORB/RIRB buffer.\r\n");
+        return -1;
+    }
 
     uint32_t *corb_rirb_buffer = (uint32_t *)vmem_phystovirt(corb_rirb_buffer_phys, (instance->corb.entcnt + 2 * instance->rirb.entcnt) * sizeof(uint32_t), vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
     instance->corb.buffer = corb_rirb_buffer;

--- a/drivers/intel_gfx/src/gmbus.c
+++ b/drivers/intel_gfx/src/gmbus.c
@@ -5,11 +5,15 @@
  * https://opensource.org/licenses/MIT
  */
 
+#include "stdbool.h"
 #include "stddef.h"
 #include "stdint.h"
 
 #include "devices.h"
 #include "gmbus.h"
+
+// Upper bound on GMBUS HW-Ready poll iterations before giving up.
+#define IGFX_GMBUS_WAIT_ITERS 1000000
 
 void igfx_gmbus_init(igfx_dev_state_t *driver_state)
 {
@@ -35,10 +39,21 @@ void igfx_gmbus_reset(igfx_dev_state_t *driver)
     igfx_gmbus_disable_writeprot(driver);
 }
 
-void igfx_gmbus_wait(igfx_dev_state_t *driver)
+// Wait for the GMBUS controller to signal HW Ready (GMBUS2 bit 11), bounding
+// the spin so a dead/absent panel or a bus error can't wedge the driver. Also
+// bails out on the NAK/error bit (GMBUS2 bit 10). Returns true on HW Ready,
+// false on timeout or error.
+bool igfx_gmbus_wait(igfx_dev_state_t *driver)
 {
-    while (!(igfx_read32(driver, driver->display_mmio_base + IGFX_GMBUS2) & (1 << 11)))
-        ;
+    for (uint32_t i = 0; i < IGFX_GMBUS_WAIT_ITERS; i++)
+    {
+        uint32_t status = igfx_read32(driver, driver->display_mmio_base + IGFX_GMBUS2);
+        if (status & (1 << 10)) // GMBUS error / NAK
+            return false;
+        if (status & (1 << 11)) // HW Ready
+            return true;
+    }
+    return false;
 }
 
 void igfx_gmbus_stoptransaction(igfx_dev_state_t *driver)
@@ -68,7 +83,12 @@ void igfx_gmbus_read(igfx_dev_state_t *driver, uint32_t disp_idx, uint8_t offset
 
     for (int i = 0; i < sz; i += 4)
     {
-        igfx_gmbus_wait(driver);
+        if (!igfx_gmbus_wait(driver))
+        {
+            // Timeout or bus error: abort the transaction instead of hanging.
+            igfx_gmbus_stoptransaction(driver);
+            return;
+        }
 
         uint32_t bytes = igfx_read32(driver, driver->display_mmio_base + IGFX_GMBUS3);
 

--- a/drivers/intel_wifi/src/firmware.c
+++ b/drivers/intel_wifi/src/firmware.c
@@ -240,6 +240,11 @@ void iwifi_fw_dma(iwifi_dev_state_t *dev, fw_section_t *sect) {
 
     //Allocate space for the chunk
     uintptr_t buf_p = pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data, IWM_FH_MEM_TB_MAX_LENGTH);
+    if (buf_p == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[iwm] Out of memory allocating firmware DMA chunk.\r\n");
+        return;
+    }
     uint8_t* buf_u8 = (uint8_t*)vmem_phystovirt((intptr_t)buf_p, IWM_FH_MEM_TB_MAX_LENGTH, vmem_flags_uncached | vmem_flags_rw | vmem_flags_kernel);
 
     //Submit the chunk to the FH dma

--- a/drivers/intel_wifi/src/main.c
+++ b/drivers/intel_wifi/src/main.c
@@ -133,6 +133,17 @@ int module_init(void *ecam_addr) {
     dev_state->tx_cmd_mem.paddr = pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data, tx_cmd_rings_sz);
     dev_state->rx_bufs_mem.paddr = pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data, rx_bufs_sz);
 
+    if (dev_state->tx_sched_mem.paddr == PHYSMEM_NO_ALLOC ||
+        dev_state->kw_mem.paddr == PHYSMEM_NO_ALLOC ||
+        dev_state->rx_mem.paddr == PHYSMEM_NO_ALLOC ||
+        dev_state->tx_mem.paddr == PHYSMEM_NO_ALLOC ||
+        dev_state->tx_cmd_mem.paddr == PHYSMEM_NO_ALLOC ||
+        dev_state->rx_bufs_mem.paddr == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[iwm] Out of memory allocating DMA rings.\r\n");
+        return -1;
+    }
+
     dev_state->tx_sched_mem.vaddr = (uint8_t*)vmem_phystovirt((intptr_t)dev_state->tx_sched_mem.paddr, tx_sched_rings_sz, vmem_flags_uncached | vmem_flags_rw | vmem_flags_kernel);
     dev_state->kw_mem.vaddr = (uint8_t*)vmem_phystovirt((intptr_t)dev_state->kw_mem.paddr, kw_page_sz, vmem_flags_uncached | vmem_flags_rw | vmem_flags_kernel);
     dev_state->rx_mem.vaddr = (uint8_t*)vmem_phystovirt((intptr_t)dev_state->rx_mem.paddr, rx_rings_sz, vmem_flags_uncached | vmem_flags_rw | vmem_flags_kernel);

--- a/drivers/rtl8139/src/driver.c
+++ b/drivers/rtl8139/src/driver.c
@@ -92,6 +92,11 @@ int rtl8139_init(rtl8139_state_t *state)
 
     //Allocate physical memory for the network buffers
     uintptr_t buffer_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_data | physmem_alloc_flags_zero | physmem_alloc_flags_32bit, RX_BUFFER_SIZE + TX_BUFFER_SIZE);
+    if (buffer_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[RTL8139] Out of memory allocating network buffers.\r\n");
+        return -1;
+    }
     intptr_t buffer_virt = vmem_phystovirt((intptr_t)buffer_phys, RX_BUFFER_SIZE + TX_BUFFER_SIZE, vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
 
     state->rx_buffer_phys = buffer_phys;

--- a/drivers/rtl8169/src/driver.c
+++ b/drivers/rtl8169/src/driver.c
@@ -125,6 +125,11 @@ int rtl8169_init(rtl8169_state_t *state)
 
     //Allocate physical memory for the network buffers
     uintptr_t buffer_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_data, RX_BUFFER_SIZE + TX_BUFFER_SIZE);
+    if (buffer_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[RTL8169] Out of memory allocating network buffers.\r\n");
+        return -1;
+    }
     intptr_t buffer_virt = vmem_phystovirt((intptr_t)buffer_phys, RX_BUFFER_SIZE + TX_BUFFER_SIZE, vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
     memset((void*)buffer_virt, 0, RX_BUFFER_SIZE + TX_BUFFER_SIZE);
 

--- a/drivers/uhci/src/main.c
+++ b/drivers/uhci/src/main.c
@@ -135,7 +135,13 @@ int module_init(void *ecam_addr)
     //Frame list: 4x1024 entries
     //Each frame contains transfer descriptors
     //Queue Heads are for bulk transfers
-    instance->framelist_pmem = (uint32_t)pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data | physmem_alloc_flags_zero, KiB(4));
+    uintptr_t framelist_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_32bit | physmem_alloc_flags_data | physmem_alloc_flags_zero, KiB(4));
+    if (framelist_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[UHCI] Out of memory allocating frame list.\r\n");
+        return -1;
+    }
+    instance->framelist_pmem = (uint32_t)framelist_phys;
     instance->framelist = (uhci_framelist_entry_t *)vmem_phystovirt((intptr_t)instance->framelist_pmem, KiB(4), vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
     instance->init_complete = false;
 

--- a/drivers/virtio/common/src/virtio_main.c
+++ b/drivers/virtio/common/src/virtio_main.c
@@ -164,6 +164,11 @@ PRIVATE void *virtio_setupqueue(virtio_state_t *state, int idx, int entcnt)
     size_t ts = 16 * entcnt + 6 + 2 * entcnt + 6 + 8 * entcnt;
 
     uintptr_t virtqueue_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_data, ts);
+    if (virtqueue_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[VirtIO] Out of memory allocating virtqueue.\r\n");
+        return NULL;
+    }
     intptr_t virtqueue_virt = vmem_phystovirt((intptr_t)virtqueue_phys, ts, vmem_flags_uncached | vmem_flags_kernel | vmem_flags_rw);
 
     memset((void *)virtqueue_virt, 0, ts);

--- a/drivers/virtio/gpu/src/main.c
+++ b/drivers/virtio/gpu/src/main.c
@@ -361,6 +361,11 @@ void virtio_gpu_displayinit_handler(virtio_virtq_cmd_state_t *cmd)
             //set its backing data
             size_t sz = display_info->pmodes[i].r.width * display_info->pmodes[i].r.height * sizeof(uint32_t);
             uintptr_t fbuf = pagealloc_alloc(0, 0, physmem_alloc_flags_data, sz);
+            if (fbuf == PHYSMEM_NO_ALLOC)
+            {
+                DEBUG_PRINT("[VirtIO-GPU] Out of memory allocating framebuffer.\r\n");
+                return;
+            }
             virtio_gpu_attachbacking(n_res_id, fbuf, sz);
 
             //set scanout

--- a/drivers/virtio/net/src/main.c
+++ b/drivers/virtio/net/src/main.c
@@ -160,6 +160,11 @@ int module_init(void *ecam)
 
     //Fill the receive virtq with buffers
     uintptr_t rcv_buf = pagealloc_alloc(0, 0, physmem_alloc_flags_data, VIRTIO_NET_QUEUE_LEN * KiB(2));
+    if (rcv_buf == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[VirtIO-Net] Out of memory allocating RX buffer.\r\n");
+        return -1;
+    }
     uint8_t *rcv_buf_virt = (uint8_t *)vmem_phystovirt((intptr_t)rcv_buf, VIRTIO_NET_QUEUE_LEN * KiB(2), vmem_flags_uncached | vmem_flags_rw | vmem_flags_kernel);
     device.rx_buf_phys = rcv_buf;
 
@@ -171,6 +176,11 @@ int module_init(void *ecam)
 
     //Allocate tx buffer
     device.tx_buf_phys = pagealloc_alloc(0, 0, physmem_alloc_flags_data, VIRTIO_NET_QUEUE_LEN * KiB(2));
+    if (device.tx_buf_phys == PHYSMEM_NO_ALLOC)
+    {
+        DEBUG_PRINT("[VirtIO-Net] Out of memory allocating TX buffer.\r\n");
+        return -1;
+    }
     device.tx_buf_virt = (uint8_t *)vmem_phystovirt((intptr_t)device.tx_buf_phys, VIRTIO_NET_QUEUE_LEN * KiB(2), vmem_flags_uncached | vmem_flags_rw | vmem_flags_kernel);
 
     //register as a network device

--- a/kernel/src/elf.c
+++ b/kernel/src/elf.c
@@ -172,7 +172,7 @@ int elf_installkernelsymbols()
     {
         shdr_cp[i].sh_addr += 0xffffffff80000000;
 
-        if ((shdr_cp[i].sh_type == SHT_SYMTAB) | (shdr_cp[i].sh_type == SHT_STRTAB))
+        if ((shdr_cp[i].sh_type == SHT_SYMTAB) || (shdr_cp[i].sh_type == SHT_STRTAB))
         {
             //Copy all shdr's into local memory too, and update addresses appropriately
             void *cur_shdr_content = malloc(shdr_cp[i].sh_size);
@@ -269,7 +269,7 @@ int elf_load(void *elf, size_t elf_len, int (**entry_point)())
     {
         Elf64_Shdr *shdr = &shdr_root[i];
 
-        if ((shdr->sh_type == SHT_STRTAB) | (shdr->sh_type == SHT_PROGBITS))
+        if ((shdr->sh_type == SHT_STRTAB) || (shdr->sh_type == SHT_PROGBITS))
             shdr->sh_addr = (uintptr_t)hdr + shdr->sh_offset;
     }
 
@@ -286,7 +286,7 @@ int elf_load(void *elf, size_t elf_len, int (**entry_point)())
                 for (uint32_t j = 0; j < shdr->sh_size / shdr->sh_entsize; j++)
                 {
 
-                    if ((sym[j].st_shndx == SHN_ABS) | (sym[j].st_shndx == SHN_UNDEF))
+                    if ((sym[j].st_shndx == SHN_ABS) || (sym[j].st_shndx == SHN_UNDEF))
                         continue;
 
                     Elf64_Shdr *sec_shdr = &shdr_root[sym[j].st_shndx];
@@ -338,7 +338,7 @@ int elf_load(void *elf, size_t elf_len, int (**entry_point)())
             for (uint32_t j = 0; j < shdr->sh_size / shdr->sh_entsize; j++)
             {
 
-                if ((sym[j].st_shndx == SHN_ABS) | (sym[j].st_shndx == SHN_UNDEF))
+                if ((sym[j].st_shndx == SHN_ABS) || (sym[j].st_shndx == SHN_UNDEF))
                     continue;
 
                 Elf64_Shdr *sec_shdr = &shdr_root[sym[j].st_shndx];

--- a/kernel/src/initrd.c
+++ b/kernel/src/initrd.c
@@ -44,7 +44,7 @@ bool Initrd_GetFile(const char *file,
 {
 
     CardinalBootInfo *bootInfo = GetBootInfo();
-    if ((bootInfo->InitrdStartAddress == 0) | (bootInfo->InitrdLength == 0))
+    if ((bootInfo->InitrdStartAddress == 0) || (bootInfo->InitrdLength == 0))
         return false;
 
     *loc = NULL;

--- a/modules/SysMemory/src/allocator.c
+++ b/modules/SysMemory/src/allocator.c
@@ -63,6 +63,12 @@ void *WEAK malloc(size_t sz)
             alloc_sz += KiB(4) - (alloc_sz % KiB(4));
 
         uintptr_t phys = pagealloc_alloc(0, 0, physmem_alloc_flags_data, alloc_sz);
+        if (phys == PHYSMEM_NO_ALLOC)
+        {
+            //Out of physical memory: fail the allocation gracefully.
+            sti(cli_state);
+            return NULL;
+        }
 
         //setup a mem_node_t at the top
         mem_node_t *n_node = (mem_node_t *)vmem_phystovirt(phys, alloc_sz, vmem_flags_cachewriteback | vmem_flags_kernel | vmem_flags_rw);

--- a/modules/SysPhysicalMemory/src/page_allocator.c
+++ b/modules/SysPhysicalMemory/src/page_allocator.c
@@ -180,7 +180,7 @@ uintptr_t pagealloc_alloc(int domain, int color, physmem_alloc_flags_t flags,
         for (int32_t i = 0; i < max_iter; i++) {
             uint64_t deq = 0;
             if (queue_trydequeue(&btm_level, &deq) == false)
-                PANIC("Out of Memory!");
+                break; // free list drained mid-scan; fall through to OOM return
 
             /*{
                     char tmp_buf[20];
@@ -221,7 +221,7 @@ uintptr_t pagealloc_alloc(int domain, int color, physmem_alloc_flags_t flags,
         compact_queue();
     }
 
-    return -1;
+    return PHYSMEM_NO_ALLOC;
 }
 
 int pagealloc_init() {

--- a/modules/SysTaskMgr/src/task.c
+++ b/modules/SysTaskMgr/src/task.c
@@ -161,6 +161,8 @@ cs_error start_task_kernel(cs_id id, void *handler, void *arg)
                     iter->user_stack += USER_STACK_LEN - sizeof(struct cardinal_program_setup_params);
 
                     uintptr_t pmem = pagealloc_alloc(0, 0, physmem_alloc_flags_data | physmem_alloc_flags_zero, USER_STACK_LEN);
+                    if (pmem == PHYSMEM_NO_ALLOC)
+                        PANIC("[SysTaskMgr] Out of memory allocating user stack.");
                     iter->user_stack_phys = pmem;
                     vmem_map(iter->mem, (intptr_t)0x100000000, (intptr_t)pmem, USER_STACK_LEN, vmem_flags_cachewriteback | vmem_flags_rw | vmem_flags_user, 0);
 
@@ -816,6 +818,8 @@ cs_error task_map(cs_id id, const char *name, intptr_t vaddr, size_t sz, task_ma
 
                 //Allocate physical memory and map it into the process
                 uintptr_t pmem = pagealloc_alloc(0, 0, physmem_alloc_flags_data | physmem_alloc_flags_instr | physmem_alloc_flags_zero, sz);
+                if (pmem == PHYSMEM_NO_ALLOC)
+                    PANIC("[SysTaskMgr] Out of memory allocating process image.");
                 d->map_entry->paddr = pmem;
                 d->map_entry->is_owner = true;
                 vmem_map(iter->mem, d->map_entry->vaddr, (intptr_t)pmem, sz, map_perms, 0);

--- a/modules/SysVirtualMemory/src/platform/x86_64/pc/vmem.c
+++ b/modules/SysVirtualMemory/src/platform/x86_64/pc/vmem.c
@@ -125,6 +125,8 @@ int vmem_init()
     wrmsr(PAT_MSR, pat);
 
     uintptr_t ktable_phys = pagealloc_alloc(-1, -1, physmem_alloc_flags_pagetable, KiB(4));
+    if (ktable_phys == PHYSMEM_NO_ALLOC)
+        PANIC("Failed to allocate kernel pagetable!");
     uint64_t *ktable = (uint64_t *)vmem_phystovirt(ktable_phys, KiB(4), vmem_flags_cachewriteback);
     memset(ktable, 0, KiB(4));
 
@@ -200,6 +202,8 @@ int vmem_mp_init()
     wrmsr(PAT_MSR, pat);
 
     uintptr_t ktable_phys = pagealloc_alloc(-1, -1, physmem_alloc_flags_pagetable, KiB(4));
+    if (ktable_phys == PHYSMEM_NO_ALLOC)
+        PANIC("Failed to allocate kernel pagetable!");
     uint64_t *ktable = (uint64_t *)vmem_phystovirt(ktable_phys, KiB(4), vmem_flags_cachewriteback);
     memset(ktable, 0, KiB(4));
 
@@ -276,7 +280,7 @@ static int vmem_map_st(uint64_t *p_vm, uint64_t *vm, intptr_t virt, intptr_t phy
             if (n_lv == 0)
             {
                 n_lv = pagealloc_alloc(-1, -1, physmem_alloc_flags_pagetable, KiB(4));
-                if (n_lv == 0)
+                if (n_lv == PHYSMEM_NO_ALLOC)
                     PANIC("Pagetable allocation failure!");
 
                 memset((uint64_t *)vmem_phystovirt(n_lv, KiB(4), vmem_flags_cachewriteback), 0, KiB(4));

--- a/modules/inc/SysPhysicalMemory/phys_mem.h
+++ b/modules/inc/SysPhysicalMemory/phys_mem.h
@@ -17,6 +17,14 @@ typedef enum {
     physmem_alloc_flags_32bit = (1 << 5),
 } physmem_alloc_flags_t;
 
+// Value returned by pagealloc_alloc when the request cannot be satisfied
+// (out of memory or too fragmented). Physical address 0 is a legal allocation,
+// so the all-ones address is used as the failure sentinel. Callers MUST check
+// the return against this before using it. Note for callers that narrow the
+// result to 32 bits (physmem_alloc_flags_32bit): check the full uintptr_t
+// return against PHYSMEM_NO_ALLOC *before* truncating.
+#define PHYSMEM_NO_ALLOC ((uintptr_t)-1)
+
 uintptr_t pagealloc_alloc(int domain, int color, physmem_alloc_flags_t flags, uint64_t size);
 
 void pagealloc_free(uintptr_t addr, uint64_t size);

--- a/notes/AUDIT.md
+++ b/notes/AUDIT.md
@@ -34,6 +34,8 @@ void igfx_gmbus_wait(igfx_dev_state_t *driver) {
 ```
 A dead/absent panel or a GMBUS error wedges the driver. Needs an iteration/time
 bound and an error-bit (GMBUS2 bit 10) check. Same pattern in the EDID read path.
+*(Fixed: `igfx_gmbus_wait` now bounds the spin and checks the error bit,
+returning failure; `igfx_gmbus_read` aborts the transaction on timeout/error.)*
 
 ### [INCOMPLETE] Haswell support is essentially absent
 - `drivers/intel_gfx/inc/hsw-regs.h` is empty (header guards only).
@@ -75,6 +77,7 @@ if ((shdr[i].sh_type == SHT_SYMTAB) | (shdr[i].sh_type == SHT_STRTAB))
 ```
 Operands are side-effect-free comparisons so the result is currently correct,
 but it defeats short-circuiting and reads as a typo. Low risk; cleanup.
+*(Fixed: switched to `||` at all listed sites.)*
 
 ### [LIKELY] pagealloc OOM sentinel is `-1` cast to `uintptr_t`
 `modules/SysPhysicalMemory/src/page_allocator.c:224` returns `-1`; callers such

--- a/notes/AUDIT.md
+++ b/notes/AUDIT.md
@@ -93,6 +93,22 @@ fired on a legitimate page at address 0 — now fixed to `== PHYSMEM_NO_ALLOC`.
 The debug-only `pmem_initial_test` is left as-is since it only prints the
 result.)*
 
+On the failure path itself there is nothing to unwind: the scan dequeues one
+free-list entry at a time and always returns it or re-inserts it before the next
+iteration, so the free list is whole at every iteration boundary. The bail
+(`page_allocator.c:182`) triggers on a *failed* `queue_trydequeue` (empty queue,
+nothing removed), so `btm_level` and `free_mem` are left exactly as they were —
+no partial allocation, no leaked pages.
+
+### [LIKELY] pagealloc re-insert failures are unchecked (page leak vector)
+`modules/SysPhysicalMemory/src/page_allocator.c:195,204,219` — when the scan
+puts a dequeued block back (wrong zone, too small, or the leftover after a
+split), it ignores the `insert_queue*` return value. If the queue is full the
+entry is silently dropped, leaking those pages and shrinking the free list (a
+later `queue_trydequeue` then fails). Independent of the OOM-sentinel work; the
+allocation logic itself otherwise conserves pages. Should check the return and
+size the queue so re-inserts cannot fail.
+
 ### [LIKELY] Unsynchronised bump allocator on SMP
 `modules/SysVirtualMemory/src/platform/x86_64/pc/vmem.c:76` — `vmem_vmalloc`
 advances `kernel_vmalloc` with no lock; the code's own TODO notes it is not

--- a/notes/AUDIT.md
+++ b/notes/AUDIT.md
@@ -83,7 +83,15 @@ but it defeats short-circuiting and reads as a typo. Low risk; cleanup.
 `modules/SysPhysicalMemory/src/page_allocator.c:224` returns `-1`; callers such
 as `modules/SysVirtualMemory/.../vmem.c:127` use the result without checking,
 so an allocation failure becomes a write to `0xFFFF…FFFF`. Define an explicit
-error sentinel and check it.
+error sentinel and check it. *(Fixed: `phys_mem.h` now defines
+`PHYSMEM_NO_ALLOC`; `pagealloc_alloc` returns it consistently on all failure
+paths (the mid-scan `PANIC` is gone). Callers handle it in tiers — critical
+infra (vmem page tables, SysMemory heap, SysTaskMgr stack/image) PANICs with a
+clear message; device drivers log and fail init/probe gracefully. Note: vmem's
+old check tested `== 0`, which both missed the real sentinel and would have
+fired on a legitimate page at address 0 — now fixed to `== PHYSMEM_NO_ALLOC`.
+The debug-only `pmem_initial_test` is left as-is since it only prints the
+result.)*
 
 ### [LIKELY] Unsynchronised bump allocator on SMP
 `modules/SysVirtualMemory/src/platform/x86_64/pc/vmem.c:76` — `vmem_vmalloc`

--- a/notes/core/Cardinal; Design Notes.txt
+++ b/notes/core/Cardinal; Design Notes.txt
@@ -83,6 +83,14 @@ SysReg:
 
 SysPhysicalMemory:
     - Physical memory management
+    - pagealloc_alloc returns a physical address, or PHYSMEM_NO_ALLOC
+      ((uintptr_t)-1) when the request cannot be satisfied. Physical address 0
+      is a legal allocation, so the all-ones address is the failure sentinel.
+      Callers MUST check the return; callers that narrow it to 32 bits must
+      check the full uintptr_t before truncating.
+    - Failure policy is tiered: critical infrastructure (page tables, kernel
+      heap backing, process stack/image) PANICs; device drivers log the
+      condition and fail init/probe gracefully so the kernel survives.
 
 SysVirtualMemory:
     - Virtual memory management

--- a/notes/drivers/iwifi/device_doc.md
+++ b/notes/drivers/iwifi/device_doc.md
@@ -73,6 +73,10 @@ Lots of work seems to be handled by the firmware.
         - An rx ring - 256-byte aligned
         - tx rings - 256 byte aligned
 
+   If any of these allocations fails (pagealloc_alloc returns PHYSMEM_NO_ALLOC),
+   the driver logs the condition and aborts init rather than proceeding with an
+   invalid physical address.
+
 4. Startup the hardware (iwm_start_hw)
     - Reset the device by setting the SW_RESET bit of CSR_RESET and waiting 10us
     - Setup and enable the associated HW_KILL interrupt.


### PR DESCRIPTION
Addresses several items from `notes/AUDIT.md`.

## GMBUS infinite busy-wait (`drivers/intel_gfx/src/gmbus.c`)
`[LIKELY]`. `igfx_gmbus_wait` spun forever on the HW-Ready bit, so a dead/absent
panel or a GMBUS error wedged the driver. Now bounded by an iteration cap,
checks the GMBUS2 error/NAK bit (bit 10), returns success/failure, and
`igfx_gmbus_read` aborts the transaction on timeout/error. The helper is
file-local, so the signature change has no external callers.

## Bitwise `|` used as logical `||` (`kernel/src/elf.c`, `kernel/src/initrd.c`)
`[LIKELY]` cleanup. Switched `|` to `||` in branch conditions at the five listed
sites. Behavior is unchanged (operands are side-effect-free comparisons) but
short-circuiting is restored.

## pagealloc OOM sentinel (`[LIKELY]`)
`pagealloc_alloc` returned a bare `-1` on failure (and `PANIC`'d on one path);
callers used the result without checking, so an allocation failure became a
write through `0xFFFF…FFFF`.

- `phys_mem.h`: define `PHYSMEM_NO_ALLOC ((uintptr_t)-1)` as the documented
  failure return (address 0 is a legal allocation, so all-ones is the sentinel).
- `page_allocator.c`: return the sentinel consistently on every failure path;
  drop the inconsistent mid-scan `PANIC`.
- **Critical infra** PANICs with a clear message: `vmem.c` (page tables),
  `SysMemory/allocator.c` (heap backing → returns NULL), `SysTaskMgr/task.c`
  (user stack / process image). Also fixed `vmem.c`'s pre-existing `== 0` check,
  which both missed the real sentinel and would have fired on a valid page at
  address 0.
- **Device drivers** log + fail init/probe gracefully instead of using a poison
  address: ahci (releases its init lock + restores interrupts first), ehci,
  uhci, hdaudio, rtl8139, rtl8169, virtio (common/net/gpu), intel_wifi.

### Not included
The three `[VERIFIED]` items the audit attributes to the correctness-fixes PR
(EDID parse, `registry_readkey_ptr`, CorePower NULL) are already fixed in this
branch. Other items (SMP bump-allocator lock, USB `def->type`, AHCI/rtl
descriptor-ownership timeouts) remain for dedicated follow-up.

https://claude.ai/code/session_016vvBDzhBEh7fGn5Ujt6iLT