### PR TITLE
intel_gfx: Ironlake (Gen5) display via firmware hand-off

### DIFF
--- a/devices.txt
+++ b/devices.txt
@@ -23,6 +23,8 @@
 ./intel_wifi.celf|8086|24fd|FFFF|FFFF|FFFF
 ./intel_gfx.celf|8086|0a16|FFFF|FFFF|FFFF
 ./intel_gfx.celf|8086|22b0|FFFF|FFFF|FFFF
+./intel_gfx.celf|8086|0046|FFFF|FFFF|FFFF
+./intel_gfx.celf|8086|0042|FFFF|FFFF|FFFF
 ./hdaudio.celf|8086|293e|FFFF|FFFF|FFFF
 ./hdaudio.celf|8086|2668|FFFF|FFFF|FFFF
 ./uhci.celf|FFFF|FFFF|000C|0003|0000

--- a/drivers/intel_gfx/inc/devices.h
+++ b/drivers/intel_gfx/inc/devices.h
@@ -12,6 +12,7 @@
 
 #define IGFX_CHERRYTRAIL 1
 #define IGFX_HASWELL 2
+#define IGFX_IRONLAKE 3
 
 #define IGFX_CHERRYTRAIL_DISP_BASE 0x180000
 #define IGFX_HASWELL_DISP_BASE 0xC0000
@@ -47,6 +48,18 @@ typedef struct
 
     uint32_t display_mmio_base;
     uint32_t gtt_base;
+
+    // BAR2 graphics aperture (GMADR) physical base, used by the Ironlake
+    // firmware hand-off path to expose the existing framebuffer.
+    uintptr_t aperture_phys;
+
+    // Active framebuffer captured from the firmware (Ironlake hand-off).
+    uintptr_t fb_virt; // CPU-visible address of the framebuffer
+    uint32_t fb_width;
+    uint32_t fb_height;
+    uint32_t fb_stride; // bytes per scanline
+    uint32_t fb_pipe;   // pipe driving the active plane
+    uint32_t fb_plane;  // active display plane index
 } igfx_dev_state_t;
 
 extern igfx_dev_t igfx_devices[];

--- a/drivers/intel_gfx/inc/ilk-regs.h
+++ b/drivers/intel_gfx/inc/ilk-regs.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Himanshu Goel
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Ironlake (Gen5) display register definitions, ported from the original
+// Cardinal "ihd" driver. Offsets are absolute from the start of the
+// MMIO/GTTMMADR BAR (BAR0), matching the igfx_read32/igfx_write32 model.
+
+#ifndef CARDINALSEMI_IGFX_ILK_REGS_H
+#define CARDINALSEMI_IGFX_ILK_REGS_H
+
+#include "stdint.h"
+
+// --- Pipes ---
+#define IGFX_ILK_PIPE_CONF(x) (0x70008 + ((x) * 0x1000))
+#define IGFX_ILK_PIPE_CONF_ENABLE (1u << 31)
+#define IGFX_ILK_PIPE_CONF_STATE (1u << 30)
+// Pipe source size: [27:16] width-1, [11:0] height-1
+#define IGFX_ILK_PIPE_SRC(x) (0x6001C + ((x) * 0x1000))
+
+// --- Primary display planes ---
+#define IGFX_ILK_DSP_CTRL(x) (0x70180 + ((x) * 0x1000))
+#define IGFX_ILK_DSP_LINOFF(x) (0x70184 + ((x) * 0x1000))
+#define IGFX_ILK_DSP_STRIDE(x) (0x70188 + ((x) * 0x1000))
+#define IGFX_ILK_DSP_SURF(x) (0x7019C + ((x) * 0x1000))
+
+#define IGFX_ILK_DSP_CTRL_ENABLE (1u << 31)
+#define IGFX_ILK_DSP_CTRL_GAMMA_ENABLE (1u << 30)
+#define IGFX_ILK_DSP_CTRL_PIXEL_MODE_OFF 26
+#define IGFX_ILK_DSP_CTRL_PIXEL_MODE_MASK 0xF
+
+// Pixel formats (DSP_CTRL bits [29:26])
+#define IGFX_ILK_PIXEL_XRGB_8888 0x6
+#define IGFX_ILK_PIXEL_XBGR_8888 0xE
+
+// --- Panel power sequencing ---
+#define IGFX_ILK_PP_STAT 0xC7200
+#define IGFX_ILK_PP_CTRL 0xC7204
+#define IGFX_ILK_PP_CTRL_BACKLIGHT (1u << 2)
+
+// --- Backlight PWM ---
+#define IGFX_ILK_BLC_PWM_CTL2 0x48250
+#define IGFX_ILK_BLC_PWM_CTL2_ENABLE (1u << 31)
+#define IGFX_ILK_BLC_PWM_CTL1 0x48254
+#define IGFX_ILK_PWM_PCH_CTRL 0xC8250
+// PWM modulation frequency: upper 16 bits hold the max brightness period
+#define IGFX_ILK_PWM_MOD_FREQ 0xC8254
+
+// --- VGA ---
+#define IGFX_ILK_VGA_PLANE_CTRL 0x41000
+#define IGFX_ILK_VGA_PLANE_CTRL_DISABLE (1u << 31)
+
+#endif

--- a/drivers/intel_gfx/inc/ilk_display.h
+++ b/drivers/intel_gfx/inc/ilk_display.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Himanshu Goel
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+#ifndef CARDINALSEMI_IGFX_ILK_DISPLAY_H
+#define CARDINALSEMI_IGFX_ILK_DISPLAY_H
+
+#include "devices.h"
+
+// Bring up the Ironlake display via firmware hand-off and register it with
+// CoreDisplay. This reuses the mode the firmware already programmed; it does
+// not perform a cold mode-set. See ilk_display.c for details.
+void igfx_ilk_init(igfx_dev_state_t *driver);
+
+#endif

--- a/drivers/intel_gfx/src/devices.c
+++ b/drivers/intel_gfx/src/devices.c
@@ -14,6 +14,8 @@
 igfx_dev_t igfx_devices[] = {
     {"Intel Haswell-ULT Integrated Graphics", 0x0a16, IGFX_HASWELL},
     {"Intel Cherrylake-E8000/J3xxx/N3xxx Graphics", 0x22b0, IGFX_CHERRYTRAIL},
+    {"Intel Ironlake Mobile (Arrandale) Graphics", 0x0046, IGFX_IRONLAKE},
+    {"Intel Ironlake Desktop (Clarkdale) Graphics", 0x0042, IGFX_IRONLAKE},
     {NULL, 0, 0}};
 
 PRIVATE int igfx_getdevice(uint16_t devID, igfx_dev_t **dev)

--- a/drivers/intel_gfx/src/display.c
+++ b/drivers/intel_gfx/src/display.c
@@ -12,6 +12,7 @@
 
 #include "display.h"
 #include "gmbus.h"
+#include "ilk_display.h"
 
 void igfx_display_init(igfx_dev_state_t *driver)
 {
@@ -33,6 +34,11 @@ void igfx_display_init(igfx_dev_state_t *driver)
                                                              // detection for HDMI D
 
         igfx_display_checkhotplugs(driver);
+    }
+    else if (driver->device->arch == IGFX_IRONLAKE)
+    {
+        // Ironlake brings up its display via the firmware hand-off path.
+        igfx_ilk_init(driver);
     }
 }
 

--- a/drivers/intel_gfx/src/ilk_display.c
+++ b/drivers/intel_gfx/src/ilk_display.c
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026 Himanshu Goel
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+// Ironlake (Gen5) display bring-up via firmware hand-off.
+//
+// This does NOT perform a cold mode-set (no FDI training / PCH DPLL /
+// transcoder programming). It assumes the firmware has already lit the panel
+// (the normal case after a UEFI/BIOS boot), reads the live plane/pipe state,
+// exposes the existing framebuffer through the graphics aperture (BAR2), and
+// registers it with CoreDisplay. A full cold mode-set is a future milestone.
+
+#include "stddef.h"
+#include "stdint.h"
+#include <types.h>
+
+#include "SysVirtualMemory/vmem.h"
+
+#include "CoreDisplay/display.h"
+
+#include "devices.h"
+#include "ilk-regs.h"
+#include "ilk_display.h"
+
+#define IGFX_ILK_MAX_PLANES 2
+
+static int igfx_ilk_getframebuffer(void *state, uintptr_t *addr)
+{
+    igfx_dev_state_t *driver = (igfx_dev_state_t *)state;
+    *addr = driver->fb_virt;
+    return 0;
+}
+
+static int igfx_ilk_getstatus(void *state, display_status_t *ans)
+{
+    (void)state;
+    *ans = display_status_connected;
+    return 0;
+}
+
+static int igfx_ilk_getdisplayinfo(void *state, display_res_info_t *res, int *entcnt)
+{
+    igfx_dev_state_t *driver = (igfx_dev_state_t *)state;
+    *entcnt = 1;
+    if (res != NULL)
+    {
+        res->w_res = (uint16_t)driver->fb_width;
+        res->h_res = (uint16_t)driver->fb_height;
+        res->stride = (uint16_t)driver->fb_stride;
+        res->refresh_rate = 60;
+    }
+    return 0;
+}
+
+static int igfx_ilk_setbrightness(void *state, uint8_t brightness)
+{
+    igfx_dev_state_t *driver = (igfx_dev_state_t *)state;
+
+    // The PWM period (max duty) lives in the upper 16 bits of PWM_MOD_FREQ.
+    uint32_t max = (igfx_read32(driver, IGFX_ILK_PWM_MOD_FREQ) >> 16) & 0xFFFF;
+    if (max == 0)
+        return -1;
+
+    uint32_t duty = ((uint32_t)brightness * max) / 255;
+    uint32_t ctl1 = igfx_read32(driver, IGFX_ILK_BLC_PWM_CTL1) & 0xFFFF0000u;
+    igfx_write32(driver, IGFX_ILK_BLC_PWM_CTL1, ctl1 | (duty & 0xFFFF));
+    return 0;
+}
+
+static int igfx_ilk_setstate(void *state, bool on)
+{
+    igfx_dev_state_t *driver = (igfx_dev_state_t *)state;
+
+    uint32_t plane_ctrl = igfx_read32(driver, IGFX_ILK_DSP_CTRL(driver->fb_plane));
+    uint32_t pp_ctrl = igfx_read32(driver, IGFX_ILK_PP_CTRL);
+
+    if (on)
+    {
+        igfx_write32(driver, IGFX_ILK_DSP_CTRL(driver->fb_plane),
+                     plane_ctrl | IGFX_ILK_DSP_CTRL_ENABLE);
+        igfx_write32(driver, IGFX_ILK_PP_CTRL, pp_ctrl | IGFX_ILK_PP_CTRL_BACKLIGHT);
+    }
+    else
+    {
+        igfx_write32(driver, IGFX_ILK_DSP_CTRL(driver->fb_plane),
+                     plane_ctrl & ~IGFX_ILK_DSP_CTRL_ENABLE);
+        igfx_write32(driver, IGFX_ILK_PP_CTRL, pp_ctrl & ~IGFX_ILK_PP_CTRL_BACKLIGHT);
+    }
+    return 0;
+}
+
+// The driver's state pointer is filled in at registration time (the device
+// state is heap-allocated, so it cannot be a static initializer).
+static display_desc_t igfx_ilk_display = {
+    .display_name = "Intel Ironlake Display",
+    .connection = display_connection_unkn,
+    .handlers = {
+        .set_resolution = NULL, // cold mode-set not implemented yet
+        .set_brightness = igfx_ilk_setbrightness,
+        .set_state = igfx_ilk_setstate,
+        .get_framebuffer = igfx_ilk_getframebuffer,
+        .get_status = igfx_ilk_getstatus,
+        .get_displayinfo = igfx_ilk_getdisplayinfo,
+        .flush = NULL, // direct scanout, no flip needed
+    },
+    .features = 0,
+    .state = NULL,
+};
+
+void igfx_ilk_init(igfx_dev_state_t *driver)
+{
+    // Find the display plane the firmware left enabled.
+    int plane = -1;
+    for (int i = 0; i < IGFX_ILK_MAX_PLANES; i++)
+    {
+        if (igfx_read32(driver, IGFX_ILK_DSP_CTRL(i)) & IGFX_ILK_DSP_CTRL_ENABLE)
+        {
+            plane = i;
+            break;
+        }
+    }
+
+    if (plane < 0)
+    {
+        // Firmware did not light a plane; the hand-off path can't bring the
+        // panel up on its own (cold mode-set is unimplemented).
+        DEBUG_PRINT("[intel_gfx] Ironlake: no firmware-enabled display plane; skipping.\r\n");
+        return;
+    }
+
+    // On Ironlake plane A drives pipe A and plane B drives pipe B.
+    uint32_t pipe = (uint32_t)plane;
+
+    uint32_t src = igfx_read32(driver, IGFX_ILK_PIPE_SRC(pipe));
+    uint32_t width = ((src >> 16) & 0xFFF) + 1;
+    uint32_t height = (src & 0xFFF) + 1;
+
+    uint32_t stride = igfx_read32(driver, IGFX_ILK_DSP_STRIDE(plane));
+    uint32_t surf = igfx_read32(driver, IGFX_ILK_DSP_SURF(plane)) & ~0xFFFu;
+
+    if (driver->aperture_phys == 0 || width <= 1 || height <= 1 || stride == 0)
+    {
+        DEBUG_PRINT("[intel_gfx] Ironlake: invalid firmware framebuffer geometry; skipping.\r\n");
+        return;
+    }
+
+    // Map the portion of the graphics aperture (BAR2) that backs the existing
+    // framebuffer. Writes through the aperture go via the GTT to the pages the
+    // firmware is already scanning out.
+    size_t map_sz = (size_t)surf + (size_t)height * stride;
+    map_sz = (map_sz + 0xFFF) & ~(size_t)0xFFF;
+
+    uint8_t *aperture = (uint8_t *)vmem_phystovirt(
+        (intptr_t)driver->aperture_phys, map_sz,
+        vmem_flags_rw | vmem_flags_uncached | vmem_flags_kernel);
+
+    driver->fb_plane = (uint32_t)plane;
+    driver->fb_pipe = pipe;
+    driver->fb_width = width;
+    driver->fb_height = height;
+    driver->fb_stride = stride;
+    driver->fb_virt = (uintptr_t)aperture + surf;
+
+    igfx_ilk_display.state = driver;
+    if (display_register(&igfx_ilk_display) != 0)
+    {
+        DEBUG_PRINT("[intel_gfx] Ironlake: display_register failed.\r\n");
+        return;
+    }
+
+    DEBUG_PRINT("[intel_gfx] Ironlake display registered (firmware hand-off).\r\n");
+}

--- a/drivers/intel_gfx/src/main.c
+++ b/drivers/intel_gfx/src/main.c
@@ -68,13 +68,30 @@ int module_init(void *ecam_addr)
             break;
     }
     dev_state->bar_phys = (uintptr_t)bar;
-    dev_state->bar = (uint8_t *)vmem_phystovirt((intptr_t)bar, KiB(4), vmem_flags_rw | vmem_flags_uncached | vmem_flags_kernel);
+
+    // Map enough of the register BAR (GTTMMADR) to reach the display registers.
+    // The default 4 KiB only covers the very start; Cherrytrail's display block
+    // begins at 0x180000 and Ironlake's PCH registers run past 0xC0000.
+    size_t mmio_sz = KiB(4);
 
     if (dev_state->device->arch == IGFX_CHERRYTRAIL)
     {
         dev_state->display_mmio_base = IGFX_CHERRYTRAIL_DISP_BASE;
         dev_state->gtt_base = IGFX_CHERRYTRAIL_GTT_BASE;
+        mmio_sz = MiB(2);
     }
+    else if (dev_state->device->arch == IGFX_IRONLAKE)
+    {
+        dev_state->display_mmio_base = IGFX_IRONLAKE_DISP_BASE;
+        mmio_sz = MiB(2);
+
+        // BAR2 is the graphics memory aperture (GMADR); the firmware framebuffer
+        // is visible through it. Capture its physical base for the hand-off path.
+        uint64_t aperture = (device->bar[2] & 0xFFFFFFF0) + ((uint64_t)device->bar[3] << 32);
+        dev_state->aperture_phys = (uintptr_t)aperture;
+    }
+
+    dev_state->bar = (uint8_t *)vmem_phystovirt((intptr_t)bar, mmio_sz, vmem_flags_rw | vmem_flags_uncached | vmem_flags_kernel);
 
     igfx_gmbus_init(dev_state);
     igfx_display_init(dev_state);


### PR DESCRIPTION
Ports the Ironlake support from the original Cardinal `ihd` driver into the new in-kernel `intel_gfx` driver, as a third arch alongside Cherrytrail/Haswell. (Background: the old repo's `hsw` target was an empty stub — the substantial display code there was actually Ironlake.)

## Scope — firmware hand-off, not a cold mode-set
v1 deliberately reuses the mode the firmware already programmed. It:
1. finds the display plane the firmware left enabled,
2. derives resolution from the pipe source register and stride/surface from the plane registers,
3. maps the slice of the **BAR2 graphics aperture** that backs the existing framebuffer,
4. registers a `display_desc_t` with CoreDisplay.

This lights up on a machine whose firmware already enabled the panel (the normal case after a UEFI/BIOS boot on the target Ironlake laptop). A true cold mode-set — FDI link training, PCH DPLL, transcoder programming — is **not** implemented here and is the natural next milestone. If the firmware left no plane enabled, the driver logs and skips rather than guessing.

## Changes
- **`inc/ilk-regs.h`** (new) — Ironlake register definitions (pipe / plane / backlight PWM / panel-power / VGA), ported from the old `ihd_regs.h` as absolute BAR0 offsets that drop straight into `igfx_read32/write32`.
- **`src/ilk_display.c`** (new) — `igfx_ilk_init()` plus the CoreDisplay handlers: `get_framebuffer`, `get_status`, `get_displayinfo`, and `set_brightness` / `set_state` wired to the BLC_PWM / PP_CTRL registers. `set_resolution`/`flush` are NULL (no mode-set, direct scanout).
- **`src/main.c`** — Ironlake arch branch: sets the MMIO base, captures the BAR2 aperture base, and widens the register-BAR mapping. (The previous `KiB(4)` mapping couldn't even reach the display register block on Cherrytrail at `0x180000` or Ironlake's PCH block past `0xC0000` — fixed to `MiB(2)`.)
- **`inc/devices.h`** — `IGFX_IRONLAKE` arch + aperture/framebuffer fields on the device state.
- **`src/display.c`** — dispatch Ironlake to `igfx_ilk_init()`.
- **`devices.c` / `devices.txt`** — register Ironlake mobile (`8086:0046`) and desktop (`8086:0042`) PCI IDs.

## Build / test status
- `intel_gfx.elf` (including the new `ilk_display.c`) **compiles and links cleanly**.
- Note: a full local build hits a pre-existing kernel-link relocation error (`tramp_stack` R_X86_64_32 in `kernel/.../main.c`) that's unrelated to this change — it's a local clang-18 vs CI clang-20 mismatch. CI (clang 20) is the authoritative build.
- Ironlake isn't emulated, so **runtime validation is pending on real hardware** (the Ironlake laptop), iterating via serial debug output.

## Follow-ups (not in this PR)
- EDID over GMBUS for the panel name / mode list (deferred; also wants the GMBUS-timeout fix from #10 to avoid an unbounded wait).
- Cold mode-set (FDI/DPLL/transcoder) for headless/cold bring-up.

https://claude.ai/code/session_016vvBDzhBEh7fGn5Ujt6iLT

---
_Generated by [Claude Code](https://claude.ai/code/session_016vvBDzhBEh7fGn5Ujt6iLT)_